### PR TITLE
Fixing issue with downloading months that don't have 2 digits. Adding…

### DIFF
--- a/src/downloading_files.py
+++ b/src/downloading_files.py
@@ -162,7 +162,7 @@ def download_by_coordinates(latitude, longitude, range=1.5, limit=float("inf")):
                 if (diff_long <= range and diff_lat <= range):
                     filename = metadata['Metadata']['scene-centre'] + ".tif"
                     date = metadata['Metadata']['end-date'].split('-')
-                    key = date[0] + "/" + date[1] + "/" + filename
+                    key = date[0] + "/" + str(int(date[1])) + "/" + filename
 
                     # We then download the file
                     if not os.path.exists(os.path.dirname(key)):

--- a/src/get_metadata.py
+++ b/src/get_metadata.py
@@ -58,18 +58,17 @@ def get_data_from_month_and_year(year = -1, month = -1):
                     columns.append('download_link')
                     list.append(columns)
                     column_names = False
-                temp = []
+                temp = [None] * len(columns)
 
                 # We then append the value of each metadata field
                 counter = 0
                 for key, value in metadata["Metadata"].items():
-                    # Sometimes there is a missing key in the metadata, this ensures a value is still given
-                    while columns[counter] != key:
-                        temp.append(None)
-                        counter += 1
-                    counter += 1
-                    temp.append(value)
-                temp.append('https://s3-ca-central-1.amazonaws.com/radarsat-r1-l1-cog/' + file['Key'])
+                    for i in range(len(columns) - 1):
+                        if columns[i] == key:
+                            temp[i] = value
+                            counter += 1
+                            break
+                temp[counter] = 'https://s3-ca-central-1.amazonaws.com/radarsat-r1-l1-cog/' + file['Key']
                 list.append(temp)
                 if (len(temp) != len(columns)):
                     print("Not equal!")
@@ -146,7 +145,7 @@ def get_data_by_country(country_name):
                     columns.append('download_link')
                     list.append(columns)
                     column_names = False
-                temp = []
+                temp = [None] * len(columns)
                 
                 # We then have to use the metadata to get the longitude and latitude
                 test = metadata['Metadata']['scene-centre']
@@ -171,13 +170,12 @@ def get_data_by_country(country_name):
                         # We then append the value of each metadata field
                         counter = 0
                         for key, value in metadata["Metadata"].items():
-                            # Sometimes there is a missing key in the metadata, this ensures a value is still given
-                            while columns[counter] != key:
-                                temp.append(None)
-                                counter += 1
-                            counter += 1
-                            temp.append(value)
-                        temp.append('https://s3-ca-central-1.amazonaws.com/radarsat-r1-l1-cog/' + file['Key'])
+                            for i in range(len(columns) - 1):
+                                if columns[i] == key:
+                                    temp[i] = value
+                                    counter += 1
+                                    break
+                        temp[counter] = 'https://s3-ca-central-1.amazonaws.com/radarsat-r1-l1-cog/' + file['Key']
                         list.append(temp)
                         if (len(temp) != len(columns)):
                             print("Not equal!")
@@ -214,3 +212,7 @@ def get_data_from_filename(file_name):
 
     # We can then create a dataframe and return it
     return pd.DataFrame(list, columns=metadata["Metadata"].keys())
+
+df = get_data_from_month_and_year(1997,7)
+print(df)
+print(df[df['sensor-mode'] == 'Fine'])

--- a/src/get_metadata.py
+++ b/src/get_metadata.py
@@ -68,7 +68,7 @@ def get_data_from_month_and_year(year = -1, month = -1):
                             temp[i] = value
                             counter += 1
                             break
-                temp[counter] = 'https://s3-ca-central-1.amazonaws.com/radarsat-r1-l1-cog/' + file['Key']
+                temp[len(columns) - 1] = 'https://s3-ca-central-1.amazonaws.com/radarsat-r1-l1-cog/' + file['Key']
                 list.append(temp)
                 if (len(temp) != len(columns)):
                     print("Not equal!")
@@ -175,7 +175,7 @@ def get_data_by_country(country_name):
                                     temp[i] = value
                                     counter += 1
                                     break
-                        temp[counter] = 'https://s3-ca-central-1.amazonaws.com/radarsat-r1-l1-cog/' + file['Key']
+                        temp[len(columns) - 1] = 'https://s3-ca-central-1.amazonaws.com/radarsat-r1-l1-cog/' + file['Key']
                         list.append(temp)
                         if (len(temp) != len(columns)):
                             print("Not equal!")
@@ -212,7 +212,3 @@ def get_data_from_filename(file_name):
 
     # We can then create a dataframe and return it
     return pd.DataFrame(list, columns=metadata["Metadata"].keys())
-
-df = get_data_from_month_and_year(1997,7)
-print(df)
-print(df[df['sensor-mode'] == 'Fine'])

--- a/src/get_metadata.py
+++ b/src/get_metadata.py
@@ -55,6 +55,7 @@ def get_data_from_month_and_year(year = -1, month = -1):
                     columns = []
                     for column in metadata["Metadata"]:
                         columns.append(column)
+                    columns.append('download_link')
                     list.append(columns)
                     column_names = False
                 temp = []
@@ -68,6 +69,7 @@ def get_data_from_month_and_year(year = -1, month = -1):
                         counter += 1
                     counter += 1
                     temp.append(value)
+                temp.append('https://s3-ca-central-1.amazonaws.com/radarsat-r1-l1-cog/' + file['Key'])
                 list.append(temp)
                 if (len(temp) != len(columns)):
                     print("Not equal!")
@@ -141,6 +143,7 @@ def get_data_by_country(country_name):
                     columns = []
                     for column in metadata["Metadata"]:
                         columns.append(column)
+                    columns.append('download_link')
                     list.append(columns)
                     column_names = False
                 temp = []
@@ -174,9 +177,10 @@ def get_data_by_country(country_name):
                                 counter += 1
                             counter += 1
                             temp.append(value)
+                        temp.append('https://s3-ca-central-1.amazonaws.com/radarsat-r1-l1-cog/' + file['Key'])
                         list.append(temp)
-                    if (len(temp) != len(columns)):
-                        print("Not equal!")
+                        if (len(temp) != len(columns)):
+                            print("Not equal!")
                 
             except Exception as e:
                 print(e)


### PR DESCRIPTION
This PR allows the metadata getting scripts to include the download link for the file.

It also fixes an issue with downloading files from months that don't have two digits (i.e January = 1 vs October = 10)